### PR TITLE
Single scan feature

### DIFF
--- a/examples/SingleReading/SingleReading.ino
+++ b/examples/SingleReading/SingleReading.ino
@@ -1,0 +1,83 @@
+/*
+Example code for Benewake TFMini time-of-flight distance sensor. 
+by Peter Jansen (December 11/2017)
+This example code is in the public domain.
+
+This example communicates to the TFMini using a SoftwareSerial port at 115200, 
+while communicating the distance results through the default Arduino hardware
+Serial debug port. 
+
+SoftwareSerial for some boards can be unreliable at high speeds (such as 115200). 
+The driver includes some limited error detection and automatic retries, that
+means it can generally work with SoftwareSerial on (for example) an UNO without
+the end-user noticing many communications glitches, as long as a constant refresh
+rate is not required. 
+
+The (UNO) circuit:
+ * Uno RX is digital pin 10 (connect to TX of TF Mini)
+ * Uno TX is digital pin 11 (connect to RX of TF Mini)
+
+THIS SOFTWARE IS PROVIDED ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+*/
+
+/*
+ * Maple Mini
+ * RX1 Pin 25, 5V tolerant -> TX TF Mini
+ * TX1 Pin 26, 5V tolerant -> RX TF Mini
+ */
+
+/*
+ * Bluepill
+ * RX1 Pin PA10 (31), 5V tolerant -> TX TF Mini
+ * TX1 Pin PA9 (30), 5V tolerant -> RX TF Mini
+ */
+ 
+#include "TFMini.h"
+TFMini tfmini;
+
+void setup() {
+  // Step 1: Initialize hardware serial port (serial debug port)
+  Serial.begin(115200);
+  // wait for serial port to connect. Needed for native USB port only
+  while (!Serial);
+     
+  Serial.println ("Initializing...");
+
+  // Step 2: Initialize the data rate for the SoftwareSerial port
+  Serial1.begin(TFMINI_BAUDRATE);
+
+  // Step 3: Initialize the TF Mini sensor
+  tfmini.begin(&Serial1);
+  delay(100);
+  
+  // Step 4: Initialize single measurement mode with external trigger
+  tfmini.setSingleScanMode();    
+}
+
+
+void loop() {
+  // Take one TF Mini distance measurement
+  tfmini.externalTrigger();
+  uint16_t dist = tfmini.getDistance();
+  uint16_t strength = tfmini.getRecentSignalStrength();
+
+  // Display the measurement
+  Serial.print("triggered - ");
+  Serial.print(dist);
+  Serial.print(",");
+  Serial.println(strength);
+
+  // Wait some time before taking the next measurement
+  // without delay, measurement is super fast
+  delay(1000);  
+}
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,9 +12,11 @@ TFMini	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin						KEYWORD2
-getDistance 				KEYWORD2
+begin				KEYWORD2
+getDistance 			KEYWORD2
 getRecentSignalStrength		KEYWORD2
+setSingleScanMode		KEYWORD2
+externalTrigger			KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/TFMini.cpp
+++ b/src/TFMini.cpp
@@ -18,7 +18,7 @@ The names of the contributors may not be used to endorse or promote products
 derived from this software without specific prior written permission.
 */
 
-#include "./TFMini.h"
+#include "TFMini.h"
 
 // Constructor
 TFMini::TFMini() { 

--- a/src/TFMini.cpp
+++ b/src/TFMini.cpp
@@ -18,7 +18,7 @@ The names of the contributors may not be used to endorse or promote products
 derived from this software without specific prior written permission.
 */
 
-#include "TFMini.h"
+#include "./TFMini.h"
 
 // Constructor
 TFMini::TFMini() { 
@@ -68,7 +68,6 @@ uint16_t TFMini::getDistance() {
   }
 }
 
-
 // Public: Return the most recent signal strength measuremenet from the TF Mini
 uint16_t TFMini::getRecentSignalStrength() {
   return strength;
@@ -86,10 +85,48 @@ void TFMini::setStandardOutputMode() {
   streamPtr->write((uint8_t)0x00);
   streamPtr->write((uint8_t)0x01);
   streamPtr->write((uint8_t)0x06);
-
-  delay(100);  
 }
 
+// Set configuration mode
+void TFMini::setConfigMode() {
+  // advanced parameter configuration mode
+  streamPtr->write((uint8_t)0x42);
+  streamPtr->write((uint8_t)0x57);
+  streamPtr->write((uint8_t)0x02);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x01);
+  streamPtr->write((uint8_t)0x02);  
+}
+
+// Set single scan mode (external trigger)
+void TFMini::setSingleScanMode() {
+  setConfigMode();
+  // setting trigger source to external
+  streamPtr->write((uint8_t)0x42);
+  streamPtr->write((uint8_t)0x57);
+  streamPtr->write((uint8_t)0x02);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x40);
+}
+
+// Send external trigger
+void TFMini::externalTrigger() {
+  setConfigMode();      
+  // send trigger
+  streamPtr->write((uint8_t)0x42);
+  streamPtr->write((uint8_t)0x57);
+  streamPtr->write((uint8_t)0x02);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x00);
+  streamPtr->write((uint8_t)0x41);
+}
 
 // Private: Handles the low-level bits of communicating with the TFMini, and detecting some communication errors.
 int TFMini::takeMeasurement() {

--- a/src/TFMini.h
+++ b/src/TFMini.h
@@ -53,10 +53,12 @@ class TFMini {
 
     // Configuration
     boolean begin(Stream* _streamPtr);
-
+    void setSingleScanMode();
+    
     // Data collection
     uint16_t getDistance();
     uint16_t getRecentSignalStrength();
+    void externalTrigger();
 
   private:
     Stream* streamPtr;
@@ -66,8 +68,8 @@ class TFMini {
     
     // Low-level communication
     void setStandardOutputMode();
+    void setConfigMode();
     int takeMeasurement();
-    
     
 };
 


### PR DESCRIPTION
Hello,

I have added a feature to set the TF MiniLidar in external trigger mode. That means it does not take a measurement every 10ms (100 Hz internal trigger) but waits for a trigger command.
I needed that for my rotating 360 degree Lidar with stepper motor.

Cheers
Stefan