### PR TITLE
Include the last frame byte in the checksum calculation

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TFMini
-version=0.1.0
+version=0.1.1
 author=Peter Jansen <upontheturtlesback@gmail.com>
 maintainer=Peter Jansen <upontheturtlesback@gmail.com>
 sentence=An Arduino driver for the Benewake TFMini time-of-flight distance sensor.

--- a/src/TFMini.cpp
+++ b/src/TFMini.cpp
@@ -174,7 +174,7 @@ int TFMini::takeMeasurement() {
     frame[i] = streamPtr->read();
 
     // Store running checksum
-    if (i < TFMINI_FRAME_SIZE-2) {
+    if (i < TFMINI_FRAME_SIZE-1) {
       checksum += frame[i];
     }
   }


### PR DESCRIPTION
Fixed checksum to include the last byte which is the temp H byte.

I was getting calculations such as the following.

```
Starting checksum: 178
0: adding 207 - new checksum: 129
1: adding 0 - new checksum: 129
2: adding 11 - new checksum: 140
3: adding 35 - new checksum: 175
4: adding 208 - new checksum: 127
----------------------------------------
i: 0: 207
i: 1: 0
i: 2: 11
i: 3: 35
i: 4: 208
i: 5: 9
i: 6: 136
127 = 136
```

You'll notice that the final checksum is 127 rather than 136 and that when calculating the checksum that frame[5] is missing. I've changed the checksum calculation to include this final byte.

After a little research, it seems that the tfmini and the tfmini-s use the same number of bytes in the frame but the tfmini-s use the last two bytes for the temperature. Either way, this change makes this library compatible with the tfmini-s as well as the tfmini.