### PR TITLE
Fixed #15 - Added optional version parameter to constructor to allow for TFMini V1.8

### DIFF
--- a/examples/BasicReading/BasicReading.ino
+++ b/examples/BasicReading/BasicReading.ino
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Setup software serial port 
 SoftwareSerial mySerial(10, 11);      // Uno RX (TFMINI TX), Uno TX (TFMINI RX)
-TFMini tfmini;
+TFMini tfmini(VER_1_0);		      // VER_1_0 or VER_1_8, default: VER_1_0
 
 void setup() {
   // Step 1: Initialize hardware serial port (serial debug port)

--- a/src/TFMini.cpp
+++ b/src/TFMini.cpp
@@ -21,7 +21,7 @@ derived from this software without specific prior written permission.
 #include "TFMini.h"
 
 // Constructor
-TFMini::TFMini(int version = VER_1_0) {
+TFMini::TFMini(int version) {
   setProtocolVersion(version);
 }
 

--- a/src/TFMini.cpp
+++ b/src/TFMini.cpp
@@ -21,8 +21,8 @@ derived from this software without specific prior written permission.
 #include "TFMini.h"
 
 // Constructor
-TFMini::TFMini() { 
-  // Empty constructor
+TFMini::TFMini(int version = VER_1_0) {
+  setProtocolVersion(version);
 }
 
 
@@ -37,7 +37,7 @@ boolean TFMini::begin(Stream* _streamPtr) {
   
   // Set standard output mode
   setStandardOutputMode();
-  
+ 
   return true;
 }
 
@@ -73,6 +73,14 @@ uint16_t TFMini::getRecentSignalStrength() {
   return strength;
 }
 
+
+// Public: Set Version
+void TFMini::setProtocolVersion(int version) {
+  checksumDiff = 2;
+  if (version == VER_1_8) {
+    checksumDiff = 1;
+  }
+}
 
 // Private: Set the TF Mini into the correct measurement mode
 void TFMini::setStandardOutputMode() {
@@ -174,7 +182,7 @@ int TFMini::takeMeasurement() {
     frame[i] = streamPtr->read();
 
     // Store running checksum
-    if (i < TFMINI_FRAME_SIZE-2) {
+    if (i < TFMINI_FRAME_SIZE-checksumDiff) {
       checksum += frame[i];
     }
   }

--- a/src/TFMini.h
+++ b/src/TFMini.h
@@ -28,6 +28,8 @@ derived from this software without specific prior written permission.
 // Defines
 #define TFMINI_BAUDRATE   115200
 #define TFMINI_DEBUGMODE  0
+#define VER_1_0		  1
+#define VER_1_8		  8
 
 // The frame size is nominally 9 characters, but we don't include the first two 0x59's marking the start of the frame
 #define TFMINI_FRAME_SIZE                 7
@@ -49,7 +51,7 @@ derived from this software without specific prior written permission.
 //
 class TFMini {
   public: 
-    TFMini(void);
+    TFMini(int version = VER_1_0);
 
     // Configuration
     boolean begin(Stream* _streamPtr);
@@ -65,11 +67,12 @@ class TFMini {
     int state;
     uint16_t distance;
     uint16_t strength;
+    int checksumDiff = 0;
     
     // Low-level communication
     void setStandardOutputMode();
     void setConfigMode();
     int takeMeasurement();
-    
+    void setProtocolVersion(int version); 
 };
 


### PR DESCRIPTION
This pull request implements the suggested fix for #15 regarding the checksum calculation on newer hardware revisions of the TFMini.

It adds an optional constructor argument (version) and some constants defining these versions.